### PR TITLE
fix whatsapp new layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ const style = document.createElement("style");
 style.setAttribute("type", "text/css");
 style.innerHTML = `
   /* Maximize WhatsApp™ Extension */
-  #maximize-wpp {
+  #maximize-wpp > div {
       max-width: initial !important;
       width: 100% !important;
       height: 100% !important;


### PR DESCRIPTION
maybe this is new break again from whatsapp web layout, and now I try to solve it, I think its solved..

this is inspect from new layout, there is another div below `#maximize-wpp`..
![Screenshot_20241217_171410](https://github.com/user-attachments/assets/81e3a58a-86f9-42df-adc2-f72e4325caab)
